### PR TITLE
Test wheels build weekly

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,6 +1,12 @@
 name: Build, test, and deploy to PyPI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    # run weekly on a Monday
+    - cron: '0 0 * * 1'
+
 env:
   MACOSX_DEPLOYMENT_TARGET: 11.0
 


### PR DESCRIPTION
This tests that wheels can be built on a scheduled timer every week, so we can detect when it breaks.