### PR TITLE
Add mac-os 15  to builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
         include:
           - {os: macos-13, arch: x86_64, build: "*"}
           - {os: macos-14, arch: arm64, build: "*"}
+          - {os: macos-15, arch: arm64, build: "*"}
           - {os: windows-2022, arch: AMD64, build: "*"}
           - {os: ubuntu-latest, arch: x86_64, build: "*"}
           - {os: ubuntu-latest, arch: aarch64, build: "*9-manylinux*"}


### PR DESCRIPTION
I was unable to install via pip on my system: `'macOS-15.3.2-arm64-arm-64bit'`

macos 15 runners were added in september: https://github.blog/changelog/2024-09-25-actions-new-images-and-ubuntu-latest-changes/

